### PR TITLE
Optionally preserve unknown object fields when both decoding and converting

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -139,6 +139,8 @@ converter.fromObject = function fromObject(mtype) {
     ("}");
         }
     } return gen
+    ("if(d.$$unk)")
+        ("m.$$unk=d.$$unk")
     ("return m");
     /* eslint-enable no-unexpected-multiline, block-scoped-var, no-redeclare */
 };
@@ -288,6 +290,8 @@ converter.toObject = function toObject(mtype) {
     ("}");
     }
     return gen
+    ("if(o.unknowns)")
+        ("Object.defineProperty(d,'$$unk',{enumerable:false,value:m.$$unk})")
     ("return d");
     /* eslint-enable no-unexpected-multiline, block-scoped-var, no-redeclare */
 };

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -95,6 +95,9 @@ function encoder(mtype) {
     }
 
     return gen
+    ("if(m.$$unk)")
+        ("for(var i=0;i<m.$$unk.length;++i)")
+            ("w.serialized(m.$$unk[i])")
     ("return w");
     /* eslint-enable no-unexpected-multiline, block-scoped-var, no-redeclare */
 }

--- a/src/message.js
+++ b/src/message.js
@@ -73,12 +73,14 @@ Message.encodeDelimited = function encodeDelimited(message, writer) {
  * @name Message.decode
  * @function
  * @param {Reader|Uint8Array} reader Reader or buffer to decode
+ * @Param 
+ * @param {boolean} [preserveUnknowns] Preserve unknown fields in a non-enumerable property
  * @returns {T} Decoded message
  * @template T extends Message<T>
  * @this Constructor<T>
  */
-Message.decode = function decode(reader) {
-    return this.$type.decode(reader);
+Message.decode = function decode(reader, preserveUnknowns) {
+    return this.$type.decode(reader, undefined, preserveUnknowns);
 };
 
 /**
@@ -86,12 +88,13 @@ Message.decode = function decode(reader) {
  * @name Message.decodeDelimited
  * @function
  * @param {Reader|Uint8Array} reader Reader or buffer to decode
+ * @param {boolean} [preserveUnknowns] Preserve unknown fields in a non-enumerable property
  * @returns {T} Decoded message
  * @template T extends Message<T>
  * @this Constructor<T>
  */
-Message.decodeDelimited = function decodeDelimited(reader) {
-    return this.$type.decodeDelimited(reader);
+Message.decodeDelimited = function decodeDelimited(reader, preserveUnknowns) {
+    return this.$type.decodeDelimited(reader, preserveUnknowns);
 };
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -499,25 +499,27 @@ Type.prototype.encodeDelimited = function encodeDelimited(message, writer) {
  * Decodes a message of this type.
  * @param {Reader|Uint8Array} reader Reader or buffer to decode from
  * @param {number} [length] Length of the message, if known beforehand
+ * @param {boolean} [preserveUnknowns] Preserve unknown fields in a non-enumerable property
  * @returns {Message<{}>} Decoded message
  * @throws {Error} If the payload is not a reader or valid buffer
  * @throws {util.ProtocolError<{}>} If required fields are missing
  */
-Type.prototype.decode = function decode_setup(reader, length) {
-    return this.setup().decode(reader, length); // overrides this method
+Type.prototype.decode = function decode_setup(reader, length, preserveUnknowns) {
+    return this.setup().decode(reader, length, preserveUnknowns); // overrides this method
 };
 
 /**
  * Decodes a message of this type preceeded by its byte length as a varint.
  * @param {Reader|Uint8Array} reader Reader or buffer to decode from
+ * @param {boolean} [preserveUnknowns] Preserve unknown fields in a non-enumerable property
  * @returns {Message<{}>} Decoded message
  * @throws {Error} If the payload is not a reader or valid buffer
  * @throws {util.ProtocolError} If required fields are missing
  */
-Type.prototype.decodeDelimited = function decodeDelimited(reader) {
+Type.prototype.decodeDelimited = function decodeDelimited(reader, preserveUnknowns) {
     if (!(reader instanceof Reader))
         reader = Reader.create(reader);
-    return this.decode(reader, reader.uint32());
+    return this.decode(reader, reader.uint32(), preserveUnknowns);
 };
 
 /**
@@ -555,6 +557,7 @@ Type.prototype.fromObject = function fromObject(object) {
  * @property {boolean} [objects=false] Sets empty objects for missing map fields even if `defaults=false`
  * @property {boolean} [oneofs=false] Includes virtual oneof properties set to the present field's name, if any
  * @property {boolean} [json=false] Performs additional JSON compatibility conversions, i.e. NaN and Infinity to strings
+ * @property {boolean} [unknowns=false] Includes unknown fields in a non-enumerable $$unk property in the resulting object
  */
 
 /**

--- a/src/writer.js
+++ b/src/writer.js
@@ -380,6 +380,15 @@ Writer.prototype.bytes = function write_bytes(value) {
 };
 
 /**
+ * Writes pre-serialized bytes.
+ * @param {Uint8Array} value Buffer to write
+ * @returns {Writer} `this`
+ */
+Writer.prototype.serialized = function write_serialized(value) {
+    return this._push(writeBytes, value.length, value)
+}
+
+/**
  * Writes a string.
  * @param {string} value Value to write
  * @returns {Writer} `this`

--- a/tests/api_unknowns.js
+++ b/tests/api_unknowns.js
@@ -1,0 +1,101 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+tape.test("sfixed64 (grpc)", function(test) {
+
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            test: {
+                nested: {
+                    Inner: {
+                        fields: {
+                            string1: {
+                                type: 'string',
+                                id: 1
+                            },
+                            string2: {
+                                type: 'string',
+                                id: 2
+                            }
+                        }
+                    },
+                    Outer: {
+                        fields: {
+                            string1: {
+                                type: 'string',
+                                id: 1
+                            },
+                            string2: {
+                                type: 'string',
+                                id: 2
+                            },
+                            inner: {
+                                type: 'Inner',
+                                id: 3
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    });
+
+    var Test = root.lookup("test.Outer");
+
+    var buffer = Test.encode({
+        string1: 'abc',
+        string2: 'def',
+        inner: {
+            string1: 'ghi',
+            string2: 'jkl'
+        }
+    }).finish();
+
+    var rootWithUnknowns = protobuf.Root.fromJSON({
+        nested: {
+            test: {
+                nested: {
+                    Inner: {
+                        fields: {
+                            string2: {
+                                type: 'string',
+                                id: 2
+                            }
+                        }
+                    },
+                    OuterWithUnknowns: {
+                        fields: {
+                            string1: {
+                                type: 'string',
+                                id: 1
+                            },
+                            inner: {
+                                type: 'Inner',
+                                id: 3
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    });
+
+    var TestWithUnknowns = rootWithUnknowns.lookup("test.OuterWithUnknowns");
+
+    var decodedWithUnknowns = TestWithUnknowns.decode(buffer, undefined, true);
+    var object = TestWithUnknowns.toObject(decodedWithUnknowns, { unknowns: true });
+
+    test.equal(object.$$unk.length, 1, "should preserve one unknown field in outer object");
+    test.equal(object.inner.$$unk.length, 1, "should preserve one unknown field in inner object");
+    test.notOk('string2' in object, "unknown fields should not be decoded");
+    test.notOk('string1' in object.inner, "unknown fields should not be decoded");
+
+    var message = TestWithUnknowns.fromObject(object);
+    var encodedBuffer = TestWithUnknowns.encode(message).finish();
+
+    test.equal(buffer.length, encodedBuffer.length, "should re-encode unknown fields resulting in buffer equal in length to original")
+
+    test.end();
+
+});


### PR DESCRIPTION
This allows the original object being converted/decoded to be re-converted/encoded to an identical length buffer.  The buffer may not necessarily be the identical to the original as fields may be re-serialized in a different order.

This property is useful for proxies/brokers/gateways that would like to inspect a message, potentially make changes to a subset of the fields, and then pass the message along.  It allows such proxies to only be aware of the fields they are interested in.